### PR TITLE
issue-2 RecordBeanHelper#trySetField will explicitly set field to NULL for string value "<null>"

### DIFF
--- a/kafka-starter-testing/src/main/java/org/galatea/kafka/starter/testing/bean/RecordBeanHelper.java
+++ b/kafka-starter-testing/src/main/java/org/galatea/kafka/starter/testing/bean/RecordBeanHelper.java
@@ -367,6 +367,12 @@ public class RecordBeanHelper {
             .maybeUseTypeConversion(wrappedBean.getPropertyType(fieldPath),
                 value);
       }
+
+      if (valueToApply != null && valueToApply.getClass().equals(String.class) &&
+          ((String) valueToApply).equalsIgnoreCase(NULL_STRING)) {
+        valueToApply = null;
+      }
+
       try {
         wrappedBean.setPropertyValue(fieldPath, valueToApply);
       } catch (TypeMismatchException e) {

--- a/kafka-starter-testing/src/test/java/org/galatea/kafka/starter/testing/bean/RecordBeanHelperTest.java
+++ b/kafka-starter-testing/src/test/java/org/galatea/kafka/starter/testing/bean/RecordBeanHelperTest.java
@@ -375,4 +375,16 @@ public class RecordBeanHelperTest {
     assertEquals(defaultValue, record.value.getNonNullableStringField());
   }
 
+  @Test
+  @SneakyThrows
+  public void createBeanRecord_setFieldNull() {
+    Map<String, String> fieldMap = new HashMap<>();
+    fieldMap.put("nullableStringField", "<null>");
+
+    KeyValue<TestMsgKey, TestMsgValue> record = RecordBeanHelper
+        .createRecord(conversionUtil, fieldMap, beanTopicConfig, true, true);
+
+    assertNull(record.value.getNullableStringField());
+  }
+
 }


### PR DESCRIPTION
RecordBeanHelper#trySetField will explicitly set field to NULL for string value "<null>"